### PR TITLE
Add client communication authorization

### DIFF
--- a/broker/components/message_dispatcher.go
+++ b/broker/components/message_dispatcher.go
@@ -11,7 +11,7 @@ type Dispatcher struct {
 	workspace *Workspace
 	ConnectionManager
 	CommandDispatcher
-	services.Transmitter
+	services.AuthProvider
 }
 
 // NewDispatcher creates new instance of Dispatcher
@@ -19,13 +19,11 @@ func NewDispatcher(
 	workspace *Workspace,
 	connectionManager ConnectionManager,
 	cmdDispatcher CommandDispatcher,
-	transmitter services.Transmitter,
 ) Dispatcher {
 	return Dispatcher{
 		workspace:         workspace,
 		ConnectionManager: connectionManager,
 		CommandDispatcher: cmdDispatcher,
-		Transmitter:       transmitter,
 	}
 }
 

--- a/broker/components/workspace.go
+++ b/broker/components/workspace.go
@@ -31,15 +31,12 @@ const (
 
 // RegisterNewUser add new user to workspace and subscribe to default channel
 func (workspace Workspace) RegisterNewUser(registrationData entity.RegistrationData) (entity.User, error) {
-	if _, ok := workspace.users[registrationData.NickName]; ok {
-		return entity.User{}, entity.UserNameAlreadyExist{Name: registrationData.NickName}
-	}
-
 	user := entity.User{
-		ID:         len(workspace.users),
-		NickName:   registrationData.NickName,
-		Connection: registrationData.Connection,
-		Channels:   []string{random},
+		ID:           len(workspace.users),
+		NickName:     registrationData.NickName,
+		PasswordHash: registrationData.PasswordHash,
+		Connection:   registrationData.Connection,
+		Channels:     []string{random},
 	}
 	workspace.users[user.NickName] = user
 	randomChannel := workspace.channels["random"]

--- a/broker/entity/errors.go
+++ b/broker/entity/errors.go
@@ -100,3 +100,13 @@ type TokenDecodingFailed struct {
 func (e TokenDecodingFailed) Error() string {
 	return fmt.Sprintf("Failed to decode auth token: %s", e.Message)
 }
+
+// InvalidToken is returned when received message from client contains invalid auth token
+// which does not belong to user or is expired
+type InvalidToken struct {
+	Reason string
+}
+
+func (e InvalidToken) Error() string {
+	return fmt.Sprintf("Received message with invalid auth token: %s", e.Reason)
+}

--- a/broker/entity/errors.go
+++ b/broker/entity/errors.go
@@ -29,13 +29,13 @@ func (e WebsocketConfigDecodingFailed) Error() string {
 	return fmt.Sprintf("Decode of websocket config failed: %s", e.Message)
 }
 
-// UserNameAlreadyExist is returned when new user tries to register with already registered nickname in workpsace
-type UserNameAlreadyExist struct {
+// UserWrongPassword is returned when new connection tries to sign in with existing username but wrong password is provided
+type UserWrongPassword struct {
 	Name string
 }
 
-func (e UserNameAlreadyExist) Error() string {
-	return fmt.Sprintf("%s user name already exist", e.Name)
+func (e UserWrongPassword) Error() string {
+	return fmt.Sprintf("Wrong password for existing user %s", e.Name)
 }
 
 // ChannelAlreadyExist is returned when user wants to create channel with name which already exist

--- a/broker/entity/register.go
+++ b/broker/entity/register.go
@@ -4,6 +4,7 @@ import "github.com/ASV44/chat-message-broker/common"
 
 // RegistrationData represents entity which combine all account data for registration with connection
 type RegistrationData struct {
-	NickName   string
-	Connection common.Connection
+	NickName     string
+	PasswordHash string
+	Connection   common.Connection
 }

--- a/broker/entity/user.go
+++ b/broker/entity/user.go
@@ -6,10 +6,11 @@ import (
 
 // User represents entity of broker user
 type User struct {
-	ID         int
-	NickName   string
-	Connection common.Connection
-	Channels   []string
+	ID           int
+	NickName     string
+	PasswordHash string
+	Connection   common.Connection
+	Channels     []string
 }
 
 func (user User) IsSubscribedToChannel(name string) bool {

--- a/broker/models/register.go
+++ b/broker/models/register.go
@@ -17,6 +17,7 @@ type Register struct {
 // AccountData represents model of message which is sent from user with all account data required at sign up
 type AccountData struct {
 	NickName string `json:"nickName"`
+	Password string `json:"password"`
 }
 
 // ToRegistrationData map AccountData model to entity.RegistrationData entity

--- a/broker/models/user.go
+++ b/broker/models/user.go
@@ -4,4 +4,5 @@ package models
 type User struct {
 	ID       int    `json:"ID"`
 	NickName string `json:"nickName"`
+	Auth     string `json:"auth"`
 }

--- a/broker/services/password_hashing.go
+++ b/broker/services/password_hashing.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// PasswordHashing hashes password or checks hash password
+type PasswordHashing interface {
+	CompareHashAndPassword(passwordHash, plainPassword string) error
+	HashPassword(password string) (string, error)
+}
+
+// LocalPasswordHashing hashes passwords with locally running BCrypt
+type LocalPasswordHashing struct {
+}
+
+// NewLocalPasswordHashing creates new instance of local password hash
+func NewLocalPasswordHashing() LocalPasswordHashing {
+	return LocalPasswordHashing{}
+}
+
+// CompareHashAndPassword compares hash and password
+func (e LocalPasswordHashing) CompareHashAndPassword(passwordHash, plainPassword string) error {
+	err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(plainPassword))
+
+	if err != nil {
+		return errors.New("hashed password is not the hash of the given password")
+	}
+
+	return nil
+}
+
+// HashPassword hashes a password and returns algorithm and hash string
+func (e LocalPasswordHashing) HashPassword(password string) (string, error) {
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(passwordHash), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/spf13/viper v1.9.0
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
### Background
<!-- In contrast to the description in the issue tracker this should provide as much technical background as possible -->
Previous implementation included proof of concept of having multiple types of communication being managed by one single broker. Client communication was implemented without any authorization. In order to provide at leas sign up and sign in by password, it is required to add client communication authorization. By client authorization on broker side, we will be able to provide secure multiple sign in and reconnects. Previous client connection was one time connection, without having possibility to reconnect after interrupting initial connection. 

### What has been done?
1. Added user sign in and sign up by password
2. Added user authorization by JWT tokens
3. Added logic for validating user authentication during communication

### How to test?
1. Build broker app and check there is no errors

### Checklist
<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [ ] I've run tests before opening PR
- [ ] I've written tests where necessary
- [x] I haven't introduced new warnings
