### PR TITLE
Add client user authorization

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -58,7 +58,7 @@ func Init(configFilePath string) (Broker, error) {
 
 	workspace := broker.NewWorkspace(configManager.Workspace())
 	transmitter := services.NewCommunicationManager()
-	cmdDispatcher := broker.NewCommandDispatcher(&workspace, transmitter)
+	cmdDispatcher := broker.NewCommandDispatcher(&workspace, authProvider, transmitter)
 	connDispatcher := broker.NewConnectionDispatcher(&workspace, cmdDispatcher, passwordHashing, authProvider)
 
 	websocketService := services.NewWebsocketProcessor(websocketConfig)
@@ -149,7 +149,7 @@ func (broker Broker) listenIncomingMessages(user entity.User) {
 func (broker Broker) validateMessageSenderAuth(sender models.User, clientAddr string) error {
 	_, claims, err := broker.authProvider.DecodeToken(sender.Auth)
 	if err != nil {
-		return err
+		return entity.InvalidToken{Reason: err.Error()}
 	}
 
 	if err = claims.Valid(); err != nil {

--- a/broker/entity/errors.go
+++ b/broker/entity/errors.go
@@ -111,11 +111,20 @@ func (e InvalidToken) Error() string {
 	return fmt.Sprintf("Received message with invalid auth token: %s", e.Reason)
 }
 
-// UserAuthFailed is returned when user authentication process failed at one step
+// UserAuthFailed is returned when user authentication process failed at some step
 type UserAuthFailed struct {
 	Reason string
 }
 
 func (e UserAuthFailed) Error() string {
 	return fmt.Sprintf("User authentication failed: %s", e.Reason)
+}
+
+// UserAuthRenewFailed is returned when user authentication renew process failed
+type UserAuthRenewFailed struct {
+	Reason string
+}
+
+func (e UserAuthRenewFailed) Error() string {
+	return fmt.Sprintf("Failed to renew user authentication: %s", e.Reason)
 }

--- a/broker/entity/errors.go
+++ b/broker/entity/errors.go
@@ -110,3 +110,12 @@ type InvalidToken struct {
 func (e InvalidToken) Error() string {
 	return fmt.Sprintf("Received message with invalid auth token: %s", e.Reason)
 }
+
+// UserAuthFailed is returned when user authentication process failed at one step
+type UserAuthFailed struct {
+	Reason string
+}
+
+func (e UserAuthFailed) Error() string {
+	return fmt.Sprintf("User authentication failed: %s", e.Reason)
+}

--- a/client/app/app.go
+++ b/client/app/app.go
@@ -89,6 +89,7 @@ func (app App) registerUserInWorkspace(connection common.Connection) error {
 		nickName := app.inputReader.GetUserInput()
 		fmt.Print("Enter password: ")
 		password := app.inputReader.GetUserSecretInput()
+		fmt.Println() // New line after providing password
 		accountData := receiver.AccountData{NickName: nickName, Password: password}
 		err := connection.SendMessage(accountData)
 		if err != nil {

--- a/client/app/app.go
+++ b/client/app/app.go
@@ -87,7 +87,9 @@ func (app App) registerUserInWorkspace(connection common.Connection) error {
 	for {
 		fmt.Print("Enter nickname: ")
 		nickName := app.inputReader.GetUserInput()
-		accountData := receiver.AccountData{NickName: nickName}
+		fmt.Print("Enter password: ")
+		password := app.inputReader.GetUserSecretInput()
+		accountData := receiver.AccountData{NickName: nickName, Password: password}
 		err := connection.SendMessage(accountData)
 		if err != nil {
 			fmt.Println("Could not write user register data ", err)

--- a/client/components/input_reader.go
+++ b/client/components/input_reader.go
@@ -4,6 +4,9 @@ import (
 	"bufio"
 	"os"
 	"strings"
+	"syscall"
+
+	"golang.org/x/term"
 )
 
 // InputReader represents component which encapsulates logic of reading user input from standard input
@@ -20,4 +23,9 @@ func NewInputReader() InputReader {
 func (inputReader InputReader) GetUserInput() string {
 	data, _ := inputReader.reader.ReadString('\n')
 	return strings.TrimSuffix(data, "\n")
+}
+
+func (inputReader InputReader) GetUserSecretInput() string {
+	secretData, _ := term.ReadPassword(syscall.Stdin)
+	return strings.TrimSuffix(string(secretData), "\n")
 }

--- a/client/models/receiver/register.go
+++ b/client/models/receiver/register.go
@@ -11,4 +11,5 @@ type Register struct {
 // AccountData represents model of message which is sent from user with all account data required at sign up
 type AccountData struct {
 	NickName string `json:"nickName"`
+	Password string `json:"password"`
 }

--- a/client/models/user.go
+++ b/client/models/user.go
@@ -4,4 +4,5 @@ package models
 type User struct {
 	ID       int    `json:"ID"`
 	NickName string `json:"nickName"`
+	Auth     string `json:"auth"`
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/spf13/viper v1.9.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,7 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
### Background
<!-- In contrast to the description in the issue tracker this should provide as much technical background as possible -->
In order to be able to reconnect and communicate securely . Client users have to follow process of authorization at connecting to workspace. Client user authorization is performed by providing user name and password at connection process. User authorization represents token provided by workspace. This token is used at communication and validates user and message sender identity.

### What has been done?
1. Added client user authorization
2. Added secure password input and sending of auth token at message sending 
3. Added renew command to broker for renewing of auth token at expiration

### How to test?
1. Build project and test communication.
2. At connecting to workspace it will require to provide password.
3. Try to disconnect and reconnect to workspace with existing credentials

### Checklist
<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [ ] I've run tests before opening PR
- [ ] I've written tests where necessary
- [x] I haven't introduced new warnings
